### PR TITLE
Eliminate name clash between Protolude.mapMaybe and Data.List.NonEmpty.mapMaybe

### DIFF
--- a/src/Data/Registry/Internal/Types.hs
+++ b/src/Data/Registry/Internal/Types.hs
@@ -8,7 +8,6 @@ module Data.Registry.Internal.Types where
 import Data.Dynamic
 import Data.Hashable
 import Data.List (elemIndex, intersect)
-import Data.List.NonEmpty
 import Data.List.NonEmpty as NonEmpty (head, last)
 import Data.MultiMap (MultiMap)
 import Data.MultiMap qualified as MM


### PR DESCRIPTION
As per https://github.com/haskell/core-libraries-committee/issues/337, a future release of `base` will introduce a new entity `Data.List.NonEmpty.mapMaybe`. Because of `Data.Registry.Internal.Types` importing both `Data.List.NonEmpty` and `Protolude` unqualified, it will be affected by a name clash:

https://github.com/etorreborre/registry/blob/8eeeafce71db18763d67dbc7214a6c9b6d4b73f0/src/Data/Registry/Internal/Types.hs#L11-L18

The PR eliminates the name clash; apparently an unqualified `Data.List.NonEmpty` was not actually used.